### PR TITLE
fix compiling on certain compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ ipsw-patch/xpwntool
 yeet
 XPwn-0.5.8-Darwin*
 openssl-1.0.2u*
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 2.6)
 project (XPwn)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcommon")
 
 # We want win32 executables to build staticly by default, since it's more difficult to keep the shared libraries straight on Windows
 IF(WIN32)


### PR DESCRIPTION
to compile on certain compilers -fcommon is needed, as -fno-common is the default on them.